### PR TITLE
Backend send roles to frontend when a round begins

### DIFF
--- a/interloperServer/src/main/java/com/interloperServer/interloperServer/service/MessagingService.java
+++ b/interloperServer/src/main/java/com/interloperServer/interloperServer/service/MessagingService.java
@@ -1,32 +1,51 @@
 package com.interloperServer.interloperServer.service;
 
-
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 
+import java.util.Map;
+
 import org.springframework.stereotype.Service;
 
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.interloperServer.interloperServer.model.Game;
 import com.interloperServer.interloperServer.model.Player;
 
 @Service
 public class MessagingService {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     /**
-     * Sends a message to all players in a game.
+     * Sends a JSON message to all players in a game.
      */
-    public void broadcastMessage(Game game, String message) {
+    public void broadcastMessage(Game game, Object message) {
         for (Player player : game.getPlayers()) {
             sendMessage(player.getSession(), message);
         }
     }
 
     /**
-     * Sends a message to a single player.
+     * Sends a JSON message to a single player.
      */
-    public void sendMessage(WebSocketSession session, String message) {
+    public void sendMessage(WebSocketSession session, Object message) {
         try {
-            session.sendMessage(new TextMessage(message));
+            // Serialize the message object to JSON
+            String jsonMessage = objectMapper.writeValueAsString(message);
+            session.sendMessage(new TextMessage(jsonMessage));
+        } catch (Exception e) {
+            e.printStackTrace();
+            sendErrorMessage(session, "Failed to serialize message to JSON.");
+        }
+    }
+
+    /**
+     * Sends an error message to a single player.
+     */
+    private void sendErrorMessage(WebSocketSession session, String errorMessage) {
+        try {
+            String jsonError = objectMapper.writeValueAsString(
+                    Map.of("event", "error", "message", errorMessage));
+            session.sendMessage(new TextMessage(jsonError));
         } catch (Exception e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
## Description

The backend now sends the roles to the players at the beginning of each round. Also updated messagingservice and message format, so that every message sent from the backend is in JSON, and has an event type. Example format: {"event":"lobbyCreated","host":"Alice","lobbyCode":"ed865d"}

Fixes #22 

### Type of change

- [x] New functionality 
- [x] Backend change


## How Has This Been Tested?

Updated unit tests to account for the new message format


## Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added tests for edge cases
- [x] New and existing unit tests pass locally with my changes
