### PR TITLE
End round if spy disconnects

### DIFF
--- a/interloperServer/Readme.md
+++ b/interloperServer/Readme.md
@@ -5,6 +5,7 @@ This is the backend server for **Interloper**, a multiplayer Spyfall-inspired ga
 ---
 
 ## 📁 Project Structure
+
 ```
 src/
 ├── main/
@@ -16,7 +17,6 @@ src/
 │   │       ├── model/                   # Game domain models and message classes
 │   │       ├── service/                 # Core business logic
 │   │       └── websocket/               # WebSocket infrastructure
-│   │           ├── GameConnectionService.java
 │   │           ├── GameWebSocketHandler.java
 │   │           ├── MessageDispatcher.java
 │   │           └── handlers/            # Individual WebSocket message handlers
@@ -31,14 +31,13 @@ src/
             └── websocket/              # WebSocket-related tests
 ```
 
-
 ---
 
 ## 🚀 Running the Server
 
 ### Prerequisites
 
-- Java 17+
+- Java 17
 - Gradle 7+
 - Recommended: IntelliJ IDEA or VS Code
 
@@ -92,7 +91,7 @@ build/reports/tests/test/index.html
 
 ## 🔌 WebSocket Endpoint
 
-- URL: `ws://<host>:8080/ws`
+- URL: `ws://<host>:8080/ws/game`
 - All messages are serialized/deserialized as JSON.
 
 ---

--- a/interloperServer/src/main/java/com/interloperServer/interloperServer/model/RoundEndReason.java
+++ b/interloperServer/src/main/java/com/interloperServer/interloperServer/model/RoundEndReason.java
@@ -4,5 +4,6 @@ public enum RoundEndReason {
     VOTES,
     SPY_GUESS,
     WRONG_VOTE,
-    TIMEOUT
+    TIMEOUT,
+    SPY_DISCONNECT
 }

--- a/interloperServer/src/main/java/com/interloperServer/interloperServer/service/GameService.java
+++ b/interloperServer/src/main/java/com/interloperServer/interloperServer/service/GameService.java
@@ -113,6 +113,16 @@ public class GameService {
                     if (game != null && game.getPlayers().size() < 3) {
                         endGame(lobbyCode);
                     }
+
+                    else if (game != null && game.getCurrentRound() != null) {
+                        Player spy = game.getCurrentRound().getSpy();
+                        if (spy != null && spy.getUsername().equals(player.getUsername())) {
+                            // Spy disconnected –> end round early
+                            roundService.endRoundDueToSpyDisconnect(lobbyCode);
+                            return;
+                        }
+                    }
+
                 }
             }
         }, DISCONNECT_BUFFER_SECONDS);

--- a/interloperServer/src/main/java/com/interloperServer/interloperServer/service/GameService.java
+++ b/interloperServer/src/main/java/com/interloperServer/interloperServer/service/GameService.java
@@ -114,6 +114,8 @@ public class GameService {
                         endGame(lobbyCode);
                     }
 
+                    // If the disconnected player is the spy -> end the round without awarding any
+                    // points
                     else if (game != null && game.getCurrentRound() != null) {
                         Player spy = game.getCurrentRound().getSpy();
                         if (spy != null && spy.getUsername().equals(player.getUsername())) {

--- a/interloperServer/src/main/java/com/interloperServer/interloperServer/service/RoundService.java
+++ b/interloperServer/src/main/java/com/interloperServer/interloperServer/service/RoundService.java
@@ -183,6 +183,35 @@ public class RoundService {
     }
 
     /**
+     * Method called when the spy is disconnected during a round
+     * Ends the round without awarding any points
+     * 
+     * @param lobbyCode
+     */
+    public void endRoundDueToSpyDisconnect(String lobbyCode) {
+        Game game = gameManagerService.getGame(lobbyCode);
+        if (game == null)
+            return;
+
+        Round currentRound = game.getCurrentRound();
+        if (currentRound == null)
+            return;
+
+        currentRound.endRound();
+        game.stopTimer();
+
+        // Broadcast end of round message
+        messagingService.broadcastMessage(game.getLobby(), messageFactory.roundEnded(
+                currentRound.getRoundNumber(),
+                RoundEndReason.SPY_DISCONNECT.toString(),
+                false,
+                false,
+                currentRound.getSpy().getUsername(),
+                currentRound.getLocation().getName(),
+                game.getScoreboard()));
+    }
+
+    /**
      * Calls award points and then broadcast the end round message
      * 
      * @param game            the current game


### PR DESCRIPTION
## Description

Ends the current round when the spy disconnects, does not award any points for the round. 

Fixes #74

### Type of change


- [x] New functionality 
- [x] Backend change


## How Has This Been Tested?

Manually


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] The solution is responsive (remove if not relevant)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added tests for edge cases
- [x] New and existing unit tests pass locally with my changes
